### PR TITLE
Add support for filter regex_replace

### DIFF
--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from celery.signals import setup_logging
 import orchestrator.logger
 
-__version__ = '0.3.7'
+__version__ = '0.3.8'
 __author__ = 'sukrit'
 
 orchestrator.logger.init_logging()

--- a/orchestrator/jinja/filters.py
+++ b/orchestrator/jinja/filters.py
@@ -29,7 +29,7 @@ def replace_regex(input_str, find, replace):
     :return: Regex replaced string
     :rtype: str
     """
-    return re.sub(find, replace, input)
+    return re.sub(find, replace, input_str)
 
 
 def apply_filters(env):

--- a/orchestrator/jinja/filters.py
+++ b/orchestrator/jinja/filters.py
@@ -1,0 +1,32 @@
+from future.builtins import (  # noqa
+    bytes, dict, int, list, object, range, str,
+    ascii, chr, hex, input, next, oct, open,
+    pow, round, filter, map, zip)
+
+import re
+
+__author__ = 'sukrit'
+
+"""
+Package that includes custom filters required for totem config processing
+"""
+
+USE_FILTERS = ('replace_regex', )
+
+
+def replace_regex(input, find, replace):
+    """Regex replace filter"""
+    return re.sub(find, replace, input)
+
+
+def apply_filters(env):
+    """
+    Applies filters on jinja env.
+
+    :param env: Jinja environment
+    :return:
+    """
+
+    for name in USE_FILTERS:
+        env.filters[name] = globals()[name]
+    return env

--- a/orchestrator/jinja/filters.py
+++ b/orchestrator/jinja/filters.py
@@ -14,8 +14,21 @@ Package that includes custom filters required for totem config processing
 USE_FILTERS = ('replace_regex', )
 
 
-def replace_regex(input, find, replace):
-    """Regex replace filter"""
+def replace_regex(input_str, find, replace):
+    """
+    Regex replace filter that replaces all occurrences of given regex match
+    in a given string
+
+    :param input_str: Input string on which replacement is to be performed
+    :type input_str: str
+    :param find: Regular expression string that needs to be used for
+        find/replacement
+    :type find: str
+    :param replace: Regex replacement string
+    :type replace: str
+    :return: Regex replaced string
+    :rtype: str
+    """
     return re.sub(find, replace, input)
 
 

--- a/orchestrator/services/config.py
+++ b/orchestrator/services/config.py
@@ -19,7 +19,7 @@ from orchestrator.cluster_config.effective import MergedConfigProvider
 from orchestrator.cluster_config.etcd import EtcdConfigProvider
 from orchestrator.cluster_config.github import GithubConfigProvider
 from orchestrator.cluster_config.s3 import S3ConfigProvider
-from orchestrator.jinja import conditions
+from orchestrator.jinja import conditions, filters
 from orchestrator.services.errors import ConfigProviderNotFound
 from orchestrator.services.exceptions import ConfigValueError, \
     ConfigValidationError, ConfigParseError
@@ -237,7 +237,8 @@ def _get_jinja_environment():
     """
     env = get_spontaneous_environment()
     env.line_statement_prefix = '#'
-    return conditions.apply_conditions(env)
+
+    return filters.apply_filters(conditions.apply_conditions(env))
 
 
 def evaluate_template(template_value, variables={}):

--- a/tests/integration/orchestrator/jinja/test_filters.py
+++ b/tests/integration/orchestrator/jinja/test_filters.py
@@ -1,0 +1,21 @@
+from jinja2 import environment
+from nose.tools import eq_
+from orchestrator.jinja import filters
+
+
+class TestJinjaFilters:
+
+    def setup(self):
+        self.env = environment.get_spontaneous_environment()
+        filters.apply_filters(self.env)
+
+    def test_regex_replace(self):
+        # Given: Jinja template using starting_with
+        template = \
+            '{{ "mock_a$b$c%d^host" | replace_regex("[^A-Za-z0-9-]","-") }}'
+
+        # When: I render template
+        ret_value = self.env.from_string(template).render()
+
+        # Then: Template is rendered as expected
+        eq_(ret_value, 'mock-a-b-c-d-host')


### PR DESCRIPTION
Add support for filter regex_replace.

We have a lot of usecase where we want to replace config using regex patter. Standard jinja2 filter does not support it and this will allow us to achieve the same.  In future, this will be migrated to config service.